### PR TITLE
Bump pragma to ^0.8.0

### DIFF
--- a/samples/SerialitySample.sol
+++ b/samples/SerialitySample.sol
@@ -1,6 +1,7 @@
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
 
-import {Seriality} from "./Seriality.sol";
+import {Seriality} from "../src/Seriality.sol";
 
 
 contract SerialitySample is Seriality {

--- a/samples/StringsReturn.sol
+++ b/samples/StringsReturn.sol
@@ -1,6 +1,7 @@
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
 
-import "./Seriality.sol";
+import "../src/Seriality.sol";
 
 contract StringsReturn is Seriality {
   

--- a/src/BytesToTypes.sol
+++ b/src/BytesToTypes.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
 
 /**
  * @title BytesToTypes

--- a/src/Seriality.sol
+++ b/src/Seriality.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
 
 /**
  * @title Seriality
@@ -12,7 +13,5 @@ import "./SizeOf.sol";
 
 contract Seriality is BytesToTypes, TypesToBytes, SizeOf {
 
-    constructor() public {
-
-    }
+    constructor() {}
 }

--- a/src/SizeOf.sol
+++ b/src/SizeOf.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
 
 /**
  * @title SizeOf

--- a/src/TypesToBytes.sol
+++ b/src/TypesToBytes.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
 
 /**
  * @title TypesToBytes
@@ -8,7 +9,7 @@ pragma solidity ^0.5.0;
 
 contract TypesToBytes {
  
-    constructor() internal {
+    constructor() {
         
     }
     function addressToBytes(uint _offst, address _input, bytes memory _output) internal pure {

--- a/tests/SerialitySample.sol
+++ b/tests/SerialitySample.sol
@@ -1,6 +1,7 @@
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
 
-import {Seriality} from "./Seriality.sol";
+import {Seriality} from "../src/Seriality.sol";
 
 
 contract SerialitySample is Seriality {

--- a/tests/StringsReturn.sol
+++ b/tests/StringsReturn.sol
@@ -1,6 +1,7 @@
-pragma solidity ^0.5.0;
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
 
-import "./Seriality.sol";
+import "../src/Seriality.sol";
 
 contract StringsReturn is Seriality {
   


### PR DESCRIPTION
This PR bumps the pragma of Seriality to ^0.8.0, and makes a couple small tweaks to satisfy the compiler errors & warning. Only minimal changes were needed to get things to compile and include:

1. Removing the `internal` modifier from the TypesToBytes constructor
2. Removing `public` modifier from the Seriality constructor (this was only a warning)
3. Adding SPDX-License-Identifier, set to Apache-2 to match the one given by @pouladzade 

I am experimenting with serialization in a project that uses pragma ^0.8.0 and in an attempt use this library, needed to bump it to the same pragma. With the changes proposed here, the library compiles and all the tests/samples pass & run exactly the same as with ^0.5.0. Beyond that, use at your own risk. Perhaps we can get a review from the author or another Solidity expert.

related to gh-6